### PR TITLE
docker: reduce images size

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: hadolint/hadolint-action@v3.0.0
         with:
           recursive: true
-          ignore: DL3041
+          ignore: DL3018
 
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
By introducing multi-stage build
And switching to alpine
And using grpcurl from docker

x20 size reduction !

```
$ docker images | grep nvidia
opi-nvidia-bridge                       main           ceced12f2cb5   21 seconds ago      74.4MB
ghcr.io/opiproject/opi-nvidia-bridge    main           613272e68e52   19 hours ago        1.72GB
```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
