### PR TITLE
tests: do not send id/name/handle OBJECT on the create request

### DIFF
--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -87,17 +87,16 @@ func dialer(opiSpdkServer *Server) func(context.Context, string) (net.Conn, erro
 }
 
 var (
-	testSubsystem = pb.NVMeSubsystem{
+	testSubsystemID = "subsystem-test"
+	testSubsystem   = pb.NVMeSubsystem{
 		Spec: &pb.NVMeSubsystemSpec{
-			Id:  &pc.ObjectKey{Value: "subsystem-test"},
 			Nqn: "nqn.2022-09.io.spdk:opi3",
 		},
 	}
-
-	testController = pb.NVMeController{
+	testControllerID = "controller-test"
+	testController   = pb.NVMeController{
 		Spec: &pb.NVMeControllerSpec{
-			Id:               &pc.ObjectKey{Value: "controller-test"},
-			SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
+			SubsystemId:      &pc.ObjectKey{Value: testSubsystemID},
 			PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
 			NvmeControllerId: 17,
 		},
@@ -105,12 +104,11 @@ var (
 			Active: true,
 		},
 	}
-
-	testNamespace = pb.NVMeNamespace{
+	testNamespaceID = "namespace-test"
+	testNamespace   = pb.NVMeNamespace{
 		Spec: &pb.NVMeNamespaceSpec{
-			Id:          &pc.ObjectKey{Value: "namespace-test"},
 			HostNsid:    22,
-			SubsystemId: testSubsystem.Spec.Id,
+			SubsystemId: &pc.ObjectKey{Value: testSubsystemID},
 			VolumeId:    &pc.ObjectKey{Value: "Malloc1"},
 		},
 		Status: &pb.NVMeNamespaceStatus{
@@ -118,9 +116,8 @@ var (
 			PciOperState: 1,
 		},
 	}
-
-	testVirtioCtrl = pb.VirtioBlk{
-		Id:       &pc.ObjectKey{Value: "virtio-blk-42"},
+	testVirtioCtrlID = "virtio-blk-42"
+	testVirtioCtrl   = pb.VirtioBlk{
 		PcieId:   &pb.PciEndpoint{PhysicalFunction: 42},
 		VolumeId: &pc.ObjectKey{Value: "Malloc42"},
 		MaxIoQps: 1,

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -51,10 +51,10 @@ func (s *Server) CreateNVMeSubsystem(_ context.Context, in *pb.CreateNVMeSubsyst
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.NvMeSubsystemId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeSubsystemId, in.NvMeSubsystem.Spec.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeSubsystemId, in.NvMeSubsystem.Spec.Id)
 		name = in.NvMeSubsystemId
 	}
-	in.NvMeSubsystem.Spec.Id.Value = name
+	in.NvMeSubsystem.Spec.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	subsys, ok := s.Subsystems[in.NvMeSubsystem.Spec.Id.Value]
 	if ok {
@@ -204,10 +204,10 @@ func (s *Server) CreateNVMeController(_ context.Context, in *pb.CreateNVMeContro
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.NvMeControllerId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeControllerId, in.NvMeController.Spec.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeControllerId, in.NvMeController.Spec.Id)
 		name = in.NvMeControllerId
 	}
-	in.NvMeController.Spec.Id.Value = name
+	in.NvMeController.Spec.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Controllers[in.NvMeController.Spec.Id.Value]
 	if ok {
@@ -375,10 +375,10 @@ func (s *Server) CreateNVMeNamespace(_ context.Context, in *pb.CreateNVMeNamespa
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.NvMeNamespaceId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeNamespaceId, in.NvMeNamespace.Spec.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeNamespaceId, in.NvMeNamespace.Spec.Id)
 		name = in.NvMeNamespaceId
 	}
-	in.NvMeNamespace.Spec.Id.Value = name
+	in.NvMeNamespace.Spec.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	namespace, ok := s.Namespaces[in.NvMeNamespace.Spec.Id.Value]
 	if ok {

--- a/pkg/frontend/virtio.go
+++ b/pkg/frontend/virtio.go
@@ -40,10 +40,10 @@ func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkReques
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.VirtioBlkId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioBlkId, in.VirtioBlk.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioBlkId, in.VirtioBlk.Id)
 		name = in.VirtioBlkId
 	}
-	in.VirtioBlk.Id.Value = name
+	in.VirtioBlk.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.VirtioCtrls[in.VirtioBlk.Id.Value]
 	if ok {

--- a/pkg/frontend/virtio_test.go
+++ b/pkg/frontend/virtio_test.go
@@ -54,7 +54,11 @@ func TestFrontEnd_CreateVirtioBlk(t *testing.T) {
 			testEnv := createTestEnvironment(true, test.spdk)
 			defer testEnv.Close()
 
-			request := &pb.CreateVirtioBlkRequest{VirtioBlk: test.in, VirtioBlkId: "virtio-blk-42"}
+			if test.out != nil {
+				test.out.Id = &pc.ObjectKey{Value: testVirtioCtrlID}
+			}
+
+			request := &pb.CreateVirtioBlkRequest{VirtioBlk: test.in, VirtioBlkId: testVirtioCtrlID}
 			response, err := testEnv.client.CreateVirtioBlk(testEnv.ctx, request)
 			if response != nil {
 				wantOut, _ := proto.Marshal(test.out)
@@ -226,7 +230,7 @@ func TestFrontEnd_ListVirtioBlks(t *testing.T) {
 					VolumeId: &pc.ObjectKey{Value: "TBD"},
 				},
 				{
-					Id:       &pc.ObjectKey{Value: "virtio-blk-42"},
+					Id:       &pc.ObjectKey{Value: testVirtioCtrlID},
 					PcieId:   &pb.PciEndpoint{PhysicalFunction: int32(0)},
 					VolumeId: &pc.ObjectKey{Value: "TBD"},
 				},
@@ -242,7 +246,7 @@ func TestFrontEnd_ListVirtioBlks(t *testing.T) {
 			"subsystem-test",
 			[]*pb.VirtioBlk{
 				{
-					Id:       &pc.ObjectKey{Value: "virtio-blk-42"},
+					Id:       &pc.ObjectKey{Value: testVirtioCtrlID},
 					PcieId:   &pb.PciEndpoint{PhysicalFunction: int32(0)},
 					VolumeId: &pc.ObjectKey{Value: "TBD"},
 				},
@@ -268,7 +272,7 @@ func TestFrontEnd_ListVirtioBlks(t *testing.T) {
 					VolumeId: &pc.ObjectKey{Value: "TBD"},
 				},
 				{
-					Id:       &pc.ObjectKey{Value: "virtio-blk-42"},
+					Id:       &pc.ObjectKey{Value: testVirtioCtrlID},
 					PcieId:   &pb.PciEndpoint{PhysicalFunction: int32(0)},
 					VolumeId: &pc.ObjectKey{Value: "TBD"},
 				},
@@ -323,15 +327,15 @@ func TestFrontEnd_GetVirtioBlk(t *testing.T) {
 		start   bool
 	}{
 		"valid request with invalid SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			nil,
 			[]string{`{"id":%d,"error":{"code":0,"message":""},"result":[]}`},
 			codes.InvalidArgument,
-			fmt.Sprintf("Could not find Controller: %v", "virtio-blk-42"),
+			fmt.Sprintf("Could not find Controller: %v", testVirtioCtrlID),
 			true,
 		},
 		"valid request with empty SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			nil,
 			[]string{""},
 			codes.Unknown,
@@ -339,7 +343,7 @@ func TestFrontEnd_GetVirtioBlk(t *testing.T) {
 			true,
 		},
 		"valid request with ID mismatch SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			nil,
 			[]string{`{"id":0,"error":{"code":0,"message":""},"result":[]}`},
 			codes.Unknown,
@@ -347,7 +351,7 @@ func TestFrontEnd_GetVirtioBlk(t *testing.T) {
 			true,
 		},
 		"valid request with error code from SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			nil,
 			[]string{`{"id":%d,"error":{"code":1,"message":"myopierr"},"result":[]}`},
 			codes.Unknown,
@@ -355,9 +359,9 @@ func TestFrontEnd_GetVirtioBlk(t *testing.T) {
 			true,
 		},
 		"valid request with valid SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			&pb.VirtioBlk{
-				Id:       &pc.ObjectKey{Value: "virtio-blk-42"},
+				Id:       &pc.ObjectKey{Value: testVirtioCtrlID},
 				PcieId:   &pb.PciEndpoint{PhysicalFunction: int32(0)},
 				VolumeId: &pc.ObjectKey{Value: "TBD"},
 			},
@@ -503,7 +507,7 @@ func TestFrontEnd_DeleteVirtioBlk(t *testing.T) {
 		missing bool
 	}{
 		"valid request with invalid SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			nil,
 			[]string{`{"id":%d,"error":{"code":0,"message":""},"result":false}`},
 			codes.InvalidArgument,
@@ -512,7 +516,7 @@ func TestFrontEnd_DeleteVirtioBlk(t *testing.T) {
 			false,
 		},
 		"valid request with empty SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			nil,
 			[]string{""},
 			codes.Unknown,
@@ -521,7 +525,7 @@ func TestFrontEnd_DeleteVirtioBlk(t *testing.T) {
 			false,
 		},
 		"valid request with ID mismatch SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			nil,
 			[]string{`{"id":0,"error":{"code":0,"message":""},"result":false}`},
 			codes.Unknown,
@@ -530,7 +534,7 @@ func TestFrontEnd_DeleteVirtioBlk(t *testing.T) {
 			false,
 		},
 		"valid request with error code from SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			nil,
 			[]string{`{"id":%d,"error":{"code":1,"message":"myopierr"},"result":false}`},
 			codes.Unknown,
@@ -539,7 +543,7 @@ func TestFrontEnd_DeleteVirtioBlk(t *testing.T) {
 			false,
 		},
 		"valid request with valid SPDK response": {
-			"virtio-blk-42",
+			testVirtioCtrlID,
 			&emptypb.Empty{},
 			[]string{`{"id":%d,"error":{"code":0,"message":""},"result":true}`}, // `{"jsonrpc": "2.0", "id": 1, "result": True}`,
 			codes.OK,


### PR DESCRIPTION
id/name/handle field is filled by the server instead
one can specify {resource}_id field instead
reduce code duplication as well in this PR

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
