### PR TITLE
Disable depguard in golangci-lint.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters-settings:
 linters:
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - errcheck
     - exportloopref


### PR DESCRIPTION
In golangci-lint 1.53.1, if depguard is enabled, it requires at least one rule specified, otherwise it forbids all packages. Disable it since we don't have any rules at the moment.