### PR TITLE
align proto clone to the same pattern

### DIFF
--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -79,7 +79,6 @@ func (s *Server) CreateNvmeSubsystem(_ context.Context, in *pb.CreateNvmeSubsyst
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	s.Subsystems[in.NvmeSubsystem.Name] = in.NvmeSubsystem
 	log.Printf("Received from SPDK: %v", result)
 	if !result {
 		msg := fmt.Sprintf("Could not create NQN: %s", in.NvmeSubsystem.Spec.Nqn)
@@ -95,6 +94,7 @@ func (s *Server) CreateNvmeSubsystem(_ context.Context, in *pb.CreateNvmeSubsyst
 	log.Printf("Received from SPDK: %v", ver)
 	response := server.ProtoClone(in.NvmeSubsystem)
 	response.Status = &pb.NvmeSubsystemStatus{FirmwareRevision: ver.Version}
+	s.Subsystems[in.NvmeSubsystem.Name] = response
 	return response, nil
 }
 
@@ -268,10 +268,10 @@ func (s *Server) CreateNvmeController(_ context.Context, in *pb.CreateNvmeContro
 		log.Print(msg)
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}
-	s.Controllers[in.NvmeController.Name] = in.NvmeController
-	s.Controllers[in.NvmeController.Name].Spec.NvmeControllerId = int32(result.Cntlid)
-	s.Controllers[in.NvmeController.Name].Status = &pb.NvmeControllerStatus{Active: true}
 	response := server.ProtoClone(in.NvmeController)
+	response.Spec.NvmeControllerId = int32(result.Cntlid)
+	response.Status = &pb.NvmeControllerStatus{Active: true}
+	s.Controllers[in.NvmeController.Name] = response
 	return response, nil
 }
 
@@ -461,9 +461,9 @@ func (s *Server) CreateNvmeNamespace(_ context.Context, in *pb.CreateNvmeNamespa
 		log.Print(msg)
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}
-	s.Namespaces[in.NvmeNamespace.Name] = in.NvmeNamespace
 	response := server.ProtoClone(in.NvmeNamespace)
 	response.Status = &pb.NvmeNamespaceStatus{PciState: 2, PciOperState: 1}
+	s.Namespaces[in.NvmeNamespace.Name] = response
 	return response, nil
 }
 

--- a/pkg/frontend/virtio.go
+++ b/pkg/frontend/virtio.go
@@ -78,9 +78,9 @@ func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkReques
 		log.Printf("Could not create: %v", in)
 		return nil, fmt.Errorf("%w for %v", errUnexpectedSpdkCallResult, in)
 	}
-	s.VirtioCtrls[in.VirtioBlk.Name] = in.VirtioBlk
-	// s.VirtioCtrls[in.VirtioBlk.Name].Status = &pb.NvmeControllerStatus{Active: true}
 	response := server.ProtoClone(in.VirtioBlk)
+	// response.Status = &pb.NvmeControllerStatus{Active: true}
+	s.VirtioCtrls[in.VirtioBlk.Name] = response
 	return response, nil
 }
 


### PR DESCRIPTION
that is separate the input from the assigned and the return object.

Fix issue opiproject#438

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
